### PR TITLE
support algolia objectid on upsert

### DIFF
--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -258,7 +258,7 @@ class DocManager(DocManagerBase):
         """ Update or insert a document into Algolia
         """
         with self.mutex:
-            self.last_object_id = serialize(doc[self.unique_key])
+            self.last_object_id = serialize(doc.get(self.unique_key) or doc['objectID'])
             filtered_doc, state = self.apply_filter(self.apply_remap(doc),
                                                     self.attributes_filter)
             filtered_doc['objectID'] = self.last_object_id


### PR DESCRIPTION
(we just fixed this issue on our fork, and thought you might want to merge upstream)

when pushing to algolia the connector takes mongo `_id` and saves it as algolia's `objectID`.
while postprocessing docs we realized this means we don't really need the `_id` in algolia.
But, if you don't send it to algolia, the next time that doc is update this line fails trying to look for that `_id` so we made it fallback to use the algolia's `objectID` in that case too.
This means now we don't need (it's not mandatory) to have that extra `_id` field saved in algolia, which is redundant.
