### PR TITLE
fixing updates and skipping unnecessary updates

### DIFF
--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -141,6 +141,9 @@ class DocManager(DocManagerBase):
         application_id, api_key, index = url.split(':')
         self.algolia = algoliasearch.Client(application_id, api_key)
         self.index = self.algolia.initIndex(index)
+        logging.info("Algolia Connector: APP is " + str(application_id))
+        logging.info("Algolia Connector: INDEX is " + str(index))
+
         self.unique_key = unique_key
         self.last_object_id = None
         self.batch = []
@@ -151,6 +154,9 @@ class DocManager(DocManagerBase):
         self.commit_sync = commit_sync
         self.commit_waittask_interval = commit_waittask_interval
         if self.auto_commit_interval not in [None, 0]:
+            logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
+            logging.info("Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size))
+            logging.info("Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)")
             self.run_auto_commit()
 
         try:
@@ -324,6 +330,7 @@ class DocManager(DocManagerBase):
                     return
                 self.index.batch({'requests': self.batch})
                 res = self.index.setSettings({'userData': {'lastObjectID': self.last_object_id}})
+                logging.debug("Algolia Connector: commited with taskID " + res['taskID'])
                 self.batch = []
                 if self.commit_sync:
                     self.index.waitTask(res['taskID'], self.commit_waittask_interval * 1000)

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -251,7 +251,7 @@ class DocManager(DocManagerBase):
             return False
 
         def attr_can_be_ignored(attr):
-            path = clean_path(re.sub(r'\.\d+\.', '.', attr))
+            path = clean_path(re.sub(r'\.(?:\$|\d+)\.', '.', attr))
             if get_at(self.attributes_filter, path, False) is not None:
                 return False
             return True

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -42,7 +42,6 @@ from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
 
 decoder = json.JSONDecoder()
 
-
 def clean_path(dirty):
     """Convert a string of python subscript notation or mongo dot-notation to a
         list of strings.
@@ -130,10 +129,10 @@ class DocManager(DocManagerBase):
 
     def __init__(self, url,
         unique_key='_id',
-        auto_commit_interval=10,
-        chunk_size=1000,
-        commit_sync=False,
-        commit_waittask_interval=1,
+        algolia_auto_commit_interval=10,
+        algolia_commit_chunk_size=1000,
+        algolia_commit_sync=False,
+        algolia_commit_waittask_interval=1,
         **kwargs):
         """Establish a connection to Algolia using target url
             'APPLICATION_ID:API_KEY:INDEX_NAME'
@@ -149,14 +148,15 @@ class DocManager(DocManagerBase):
         self.batch = []
         self.mutex = RLock()
 
-        self.auto_commit_interval = auto_commit_interval
-        self.chunk_size = chunk_size
-        self.commit_sync = commit_sync
-        self.commit_waittask_interval = commit_waittask_interval
+        self.auto_commit_interval = algolia_auto_commit_interval
+        self.chunk_size = algolia_commit_chunk_size
+        self.commit_sync = algolia_commit_sync
+        self.commit_waittask_interval = algolia_commit_waittask_interval
         if self.auto_commit_interval not in [None, 0]:
-            logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
-            logging.info("Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size))
-            logging.info("Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)")
+            logging.info("Algolia Connector: algolia_auto_commit_interval every " + str(self.auto_commit_interval) + " second(s)")
+            logging.info("Algolia Connector: algolia_commit_chunk_size is " + str(self.chunk_size))
+            logging.info("Algolia Connector: algolia_commit_sync is " + str(self.commit_sync))
+            logging.info("Algilia Connector: algolia_commit_waittask_interval is " + str(self.commit_waittask_interval) + " second(s)")
             self.run_auto_commit()
 
         try:

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -330,7 +330,7 @@ class DocManager(DocManagerBase):
                     return
                 self.index.batch({'requests': self.batch})
                 res = self.index.setSettings({'userData': {'lastObjectID': self.last_object_id}})
-                logging.debug("Algolia Connector: commited with taskID " + res['taskID'])
+                logging.debug("Algolia Connector: commited with taskID " + str(res['taskID']))
                 self.batch = []
                 if self.commit_sync:
                     self.index.waitTask(res['taskID'], self.commit_waittask_interval * 1000)

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -110,6 +110,8 @@ def filter_value(value, expr):
     """Evaluate the given expression in the context of the given value."""
     if expr == "":
         return True
+    if value is None:
+        return False
     try:
         return eval(re.sub(r'\$_', 'value', expr))
     except Exception as e:

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -142,7 +142,9 @@ class DocManager(DocManagerBase):
         self.algolia = algoliasearch.Client(application_id, api_key)
         self.index = self.algolia.initIndex(index)
         logging.info("Algolia Connector: APP is " + str(application_id))
+        print "Algolia Connector: APP is " + str(application_id)
         logging.info("Algolia Connector: INDEX is " + str(index))
+        print "Algolia Connector: INDEX is " + str(index)
 
         self.unique_key = unique_key
         self.last_object_id = None
@@ -157,6 +159,9 @@ class DocManager(DocManagerBase):
             logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
             logging.info("Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size))
             logging.info("Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)")
+            print "Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)"
+            print "Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size)
+            print "Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)"
             self.run_auto_commit()
 
         try:
@@ -389,6 +394,7 @@ class DocManager(DocManagerBase):
                 self.index.batch({'requests': self.batch})
                 res = self.index.setSettings({'userData': {'lastObjectID': self.last_object_id}})
                 logging.debug("Algolia Connector: commited with taskID " + str(res['taskID']))
+                print "Algolia Connector: commited with taskID " + str(res['taskID'])
                 self.batch = []
                 if self.commit_sync:
                     self.index.waitTask(res['taskID'], self.commit_waittask_interval * 1000)
@@ -401,10 +407,10 @@ class DocManager(DocManagerBase):
         """
         try:
             logging.debug("Algolia Connector: periodical commit attempt")
+            print "Algolia Connector: periodical commit attempt"
             self.commit()
         except Exception as e:
             logging.warning(e)
-        logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
         if self.auto_commit_interval not in [None, 0]:
             Timer(self.auto_commit_interval, self.run_auto_commit).start()
 

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -270,6 +270,18 @@ class DocManager(DocManagerBase):
                     return False
 
         logging.debug("Algolia Connector: Update can be ignored")
+
+        if "$set" in update_spec:
+            specAttrs = self.apply_remap(update_spec["$set"])
+            for attr in specAttrs:
+                if attr_can_be_ignored(attr):
+                    logging.debug("Ignoring: $set " + attr)
+        if "$unset" in update_spec:
+            specAttrs = self.apply_remap(update_spec["$unset"])
+            for attr in specAttrs:
+                if attr_can_be_ignored(attr):
+                    logging.debug("Ignoring: $unset " + attr)
+
         return True
 
     def _db_and_collection(self, namespace):

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -132,7 +132,7 @@ class DocManager(DocManagerBase):
         unique_key='_id',
         auto_commit_interval=10,
         chunk_size=1000,
-        commit_sync=False,
+        commit_sync=True,
         commit_waittask_interval=1,
         **kwargs):
         """Establish a connection to Algolia using target url
@@ -400,6 +400,7 @@ class DocManager(DocManagerBase):
         """ Periodically commits to Algolia.
         """
         try:
+            logging.debug("Algolia Connector: periodical commit attempt")
             self.commit()
         except Exception as e:
             logging.warning(e)

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -128,9 +128,11 @@ class DocManager(DocManagerBase):
         Algolia's native 'objectID' field is used to store the unique_key.
         """
 
-    def __init__(self, url, unique_key='_id',
-        auto_commit_interval=DEFAULT_COMMIT_INTERVAL,
-        chunk_size=DEFAULT_MAX_BULK,  **kwargs):
+    def __init__(self, url,
+        unique_key='_id',
+        auto_commit_interval=10,
+        chunk_size=1000,
+        **kwargs):
         """Establish a connection to Algolia using target url
             'APPLICATION_ID:API_KEY:INDEX_NAME'
         """

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -132,7 +132,7 @@ class DocManager(DocManagerBase):
         unique_key='_id',
         auto_commit_interval=10,
         chunk_size=1000,
-        commit_sync=True,
+        commit_sync=False,
         commit_waittask_interval=1,
         **kwargs):
         """Establish a connection to Algolia using target url
@@ -404,6 +404,7 @@ class DocManager(DocManagerBase):
             self.commit()
         except Exception as e:
             logging.warning(e)
+        logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
         if self.auto_commit_interval not in [None, 0]:
             Timer(self.auto_commit_interval, self.run_auto_commit).start()
 

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -143,7 +143,9 @@ class DocManager(DocManagerBase):
         self.batch = []
         self.mutex = RLock()
         self.auto_commit = kwargs.pop('auto_commit', True)
-        self.run_auto_commit()
+        if self.auto_commit:
+            self.run_auto_commit()
+
         try:
             json = open("algolia_fields_" + index + ".json", 'r')
             self.attributes_filter = decoder.decode(json.read())

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0, commit_sync=True)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit=False)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0, commit_sync=True)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), algolia_auto_commit_interval=0, algolia_commit_sync=True)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia_doc_manager.py
+++ b/tests/test_algolia_doc_manager.py
@@ -33,23 +33,23 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the update method."""
         doc = {"_id": '1', "a": 1, "b": 2}
         self.algolia_doc.upsert(doc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         # $set only
         update_spec = {"$set": {"a": 1, "b": 2}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "a": 1, "b": 2})
         # $unset only
         update_spec = {"$unset": {"a": True}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "b": 2, "a": None})
         # mixed $set/$unset
         update_spec = {"$unset": {"b": True}, "$set": {"c": 3}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "c": 3, "a": None, "b": None})
 
@@ -57,7 +57,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the upsert method."""
         docc = {'_id': '1', 'name': 'John'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         for doc in res:
             self.assertEqual(doc['_id'], '1')
@@ -66,11 +66,11 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
         self.algolia_doc.bulk_upsert([], *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         docs = ({"_id": i} for i in range(100))
         self.algolia_doc.bulk_upsert(docs, *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('', { 'hitsPerPage': 101 })["hits"]
         returned_ids = sorted(int(doc["_id"]) for doc in res)
         self.assertEqual(len(returned_ids), 100)
@@ -79,7 +79,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
 
         docs = ({"_id": i, "weight": 2*i} for i in range(100))
         self.algolia_doc.bulk_upsert(docs, *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         res = self.algolia_index.search('', { 'hitsPerPage': 101 })["hits"]
         returned_ids = sorted(int(doc["weight"]) for doc in res)
@@ -91,12 +91,12 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the remove method."""
         docc = {'_id': '1', 'name': 'John'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         self.assertEqual(len(res), 1)
 
         self.algolia_doc.remove(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         self.assertEqual(len(res), 0)
 
@@ -114,7 +114,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         self.algolia_doc.upsert(docc)
         docc = {'_id': '6', 'name': 'Mr T.', '_ts': ts+1, 'ns': 'test.test'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         self.assertEqual(self.algolia_index.search('')['nbHits'], 3)
         doc = self.elastic_doc.get_last_doc()
@@ -122,7 +122,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
 
         docc = {'_id': '6', 'name': 'HareTwin', '_ts': ts+4, 'ns': 'test.test'}
         self.elastic_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         doc = self.elastic_doc.get_last_doc()
         self.assertEqual(doc['_id'], '6')


### PR DESCRIPTION
hi guys, this might be a big change to be merged lightly, but I'm sending it in case you guys find this, or part of this, useful.
## 1. skip updates based on filters

I added the `update_can_be_ignored` function that will use the json attributes_filter to filter the mongo update_spec ($set and $unset), if no field passed thru the filter, that means the update won't have any impact in the algolia index, so the update is skipped.
we are using this to avoid a lot of unnecessary operations.
## 2. support updates when a postproc script is used

we realized this functionality is sort of broken right now, current behavior when an update arrive is:
1. read the doc from algolia
2. apply the mongo update_spec to that doc, see [here](#diff-729ca26bf37889aa5544cacd92f552e7L26)
3. apply remap and filter
4. postproc
5. send to algolia as partialUpdate

the problem here is step 2, that apply_update is trying to apply an update that is for the original mongo document, to the algolia doc, which if you use a postproc script, will have a different structure.
Now, depending on how desctructive your postproc is, there's no way to recreate the doc from the algolia doc (the postproc result), for example, we index products, and we delete from the doc variants out of stock, but when an update comes saying stock is back, we need to readd it, that is impossible without grabbing the original mongo document.

If you check the Elastic Search doc manager, you'll notice they solved this problem by including the source doc (untransformed) as a child property `"source"`, but we didn't want to do that for 2 reasons:
- algolia doc size limit (our postproc reduces the doc size significantly)
- an extra operation of reading the algolia doc

so we decided the cheapest and safest is to read the doc from mongo instead (unfortunately that means I had to modify the connector class to share the mongo connection with the doc manager).

the result is now, when an update arrives there are 4 possible results:
### a. update skipped

if the update has $set and $unset, and the fields updated are all filtered out, update is skipped
cost: zero
### b. doc replace

if the update is a doc replace, the update_spec is the full doc (no $set or $unset), so that is filter+remap+postproc, and sent to algolia
cost: 1 algolia operation
### c. reprocessing original doc

if there is a postproc script, and a partial update, the doc is read from mongo (using the mongo client obtained from the connector), and the obtained doc is filter+remap+postproc, and sent to algolia
cost: 1 mongo read + 1 algolia operation
### d. sending a partial update

if there is no postproc, then it is possible to convert the mongo update_spec into an algolia partial update, and that is sent as an algolia partial update.
cost: 1 algolia operation
