### PR TITLE
Commit operations improvements

### DIFF
--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -141,6 +141,9 @@ class DocManager(DocManagerBase):
         application_id, api_key, index = url.split(':')
         self.algolia = algoliasearch.Client(application_id, api_key)
         self.index = self.algolia.initIndex(index)
+        logging.info("Algolia Connector: APP is " + str(application_id))
+        logging.info("Algolia Connector: INDEX is " + str(index))
+
         self.unique_key = unique_key
         self.last_object_id = None
         self.batch = []
@@ -151,6 +154,9 @@ class DocManager(DocManagerBase):
         self.commit_sync = commit_sync
         self.commit_waittask_interval = commit_waittask_interval
         if self.auto_commit_interval not in [None, 0]:
+            logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
+            logging.info("Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size))
+            logging.info("Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)")
             self.run_auto_commit()
 
         try:
@@ -324,6 +330,7 @@ class DocManager(DocManagerBase):
                     return
                 self.index.batch({'requests': self.batch})
                 res = self.index.setSettings({'userData': {'lastObjectID': self.last_object_id}})
+                logging.debug("Algolia Connector: commited with taskID " + res['taskID'])
                 self.batch = []
                 if self.commit_sync:
                     self.index.waitTask(res['taskID'], self.commit_waittask_interval * 1000)

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -42,7 +42,6 @@ from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
 
 decoder = json.JSONDecoder()
 
-
 def clean_path(dirty):
     """Convert a string of python subscript notation or mongo dot-notation to a
         list of strings.
@@ -130,10 +129,10 @@ class DocManager(DocManagerBase):
 
     def __init__(self, url,
         unique_key='_id',
-        auto_commit_interval=10,
-        chunk_size=1000,
-        commit_sync=False,
-        commit_waittask_interval=1,
+        algolia_auto_commit_interval=10,
+        algolia_commit_chunk_size=1000,
+        algolia_commit_sync=False,
+        algolia_commit_waittask_interval=1,
         **kwargs):
         """Establish a connection to Algolia using target url
             'APPLICATION_ID:API_KEY:INDEX_NAME'
@@ -149,14 +148,15 @@ class DocManager(DocManagerBase):
         self.batch = []
         self.mutex = RLock()
 
-        self.auto_commit_interval = auto_commit_interval
-        self.chunk_size = chunk_size
-        self.commit_sync = commit_sync
-        self.commit_waittask_interval = commit_waittask_interval
+        self.auto_commit_interval = algolia_auto_commit_interval
+        self.chunk_size = algolia_commit_chunk_size
+        self.commit_sync = algolia_commit_sync
+        self.commit_waittask_interval = algolia_commit_waittask_interval
         if self.auto_commit_interval not in [None, 0]:
-            logging.info("Algolia Connector: AUTO_COMMIT_INTERVAL every " + str(self.auto_commit_interval) + " second(s)")
-            logging.info("Algolia Connector: CHUNK_SIZE is " + str(self.chunk_size))
-            logging.info("Algilia Connector: COMMIT_WAITTASK_INTERVAL is " + str(self.commit_waittask_interval) + " second(s)")
+            logging.info("Algolia Connector: algolia_auto_commit_interval every " + str(self.auto_commit_interval) + " second(s)")
+            logging.info("Algolia Connector: algolia_commit_chunk_size is " + str(self.chunk_size))
+            logging.info("Algolia Connector: algolia_commit_sync is " + str(self.commit_sync))
+            logging.info("Algilia Connector: algolia_commit_waittask_interval is " + str(self.commit_waittask_interval) + " second(s)")
             self.run_auto_commit()
 
         try:

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -330,7 +330,7 @@ class DocManager(DocManagerBase):
                     return
                 self.index.batch({'requests': self.batch})
                 res = self.index.setSettings({'userData': {'lastObjectID': self.last_object_id}})
-                logging.debug("Algolia Connector: commited with taskID " + res['taskID'])
+                logging.debug("Algolia Connector: commited with taskID " + str(res['taskID']))
                 self.batch = []
                 if self.commit_sync:
                     self.index.waitTask(res['taskID'], self.commit_waittask_interval * 1000)

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -128,9 +128,11 @@ class DocManager(DocManagerBase):
         Algolia's native 'objectID' field is used to store the unique_key.
         """
 
-    def __init__(self, url, unique_key='_id',
-        auto_commit_interval=DEFAULT_COMMIT_INTERVAL,
-        chunk_size=DEFAULT_MAX_BULK,  **kwargs):
+    def __init__(self, url,
+        unique_key='_id',
+        auto_commit_interval=10,
+        chunk_size=1000,
+        **kwargs):
         """Establish a connection to Algolia using target url
             'APPLICATION_ID:API_KEY:INDEX_NAME'
         """

--- a/mongo_connector/doc_managers/algolia_doc_manager.py
+++ b/mongo_connector/doc_managers/algolia_doc_manager.py
@@ -143,7 +143,9 @@ class DocManager(DocManagerBase):
         self.batch = []
         self.mutex = RLock()
         self.auto_commit = kwargs.pop('auto_commit', True)
-        self.run_auto_commit()
+        if self.auto_commit:
+            self.run_auto_commit()
+
         try:
             json = open("algolia_fields_" + index + ".json", 'r')
             self.attributes_filter = decoder.decode(json.read())

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0, commit_sync=True)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit=False)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia.py
+++ b/tests/test_algolia.py
@@ -38,7 +38,7 @@ class AlgoliaTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.algolia_client = algoliasearch.Client(os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'])
-        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), auto_commit_interval=0, commit_sync=True)
+        cls.algolia_doc = DocManager('%s:%s:%s' % (os.environ['ALGOLIA_APPLICATION_ID'], os.environ['ALGOLIA_API_KEY'], 'test_mongo_connector'), algolia_auto_commit_interval=0, algolia_commit_sync=True)
 
     def setUp(self):
         self.algolia_index = self.algolia_client.initIndex('test_mongo_connector')

--- a/tests/test_algolia_doc_manager.py
+++ b/tests/test_algolia_doc_manager.py
@@ -33,23 +33,23 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the update method."""
         doc = {"_id": '1', "a": 1, "b": 2}
         self.algolia_doc.upsert(doc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         # $set only
         update_spec = {"$set": {"a": 1, "b": 2}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "a": 1, "b": 2})
         # $unset only
         update_spec = {"$unset": {"a": True}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "b": 2, "a": None})
         # mixed $set/$unset
         update_spec = {"$unset": {"b": True}, "$set": {"c": 3}}
         self.algolia_doc.update(doc, update_spec)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         doc = self.algolia_index.getObject('1')
         self.assertEqual(doc, {"_id": '1', "objectID": '1', "c": 3, "a": None, "b": None})
 
@@ -57,7 +57,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the upsert method."""
         docc = {'_id': '1', 'name': 'John'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         for doc in res:
             self.assertEqual(doc['_id'], '1')
@@ -66,11 +66,11 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
         self.algolia_doc.bulk_upsert([], *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         docs = ({"_id": i} for i in range(100))
         self.algolia_doc.bulk_upsert(docs, *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('', { 'hitsPerPage': 101 })["hits"]
         returned_ids = sorted(int(doc["_id"]) for doc in res)
         self.assertEqual(len(returned_ids), 100)
@@ -79,7 +79,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
 
         docs = ({"_id": i, "weight": 2*i} for i in range(100))
         self.algolia_doc.bulk_upsert(docs, *TESTARGS)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         res = self.algolia_index.search('', { 'hitsPerPage': 101 })["hits"]
         returned_ids = sorted(int(doc["weight"]) for doc in res)
@@ -91,12 +91,12 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         """Test the remove method."""
         docc = {'_id': '1', 'name': 'John'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         self.assertEqual(len(res), 1)
 
         self.algolia_doc.remove(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
         res = self.algolia_index.search('')["hits"]
         self.assertEqual(len(res), 0)
 
@@ -114,7 +114,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
         self.algolia_doc.upsert(docc)
         docc = {'_id': '6', 'name': 'Mr T.', '_ts': ts+1, 'ns': 'test.test'}
         self.algolia_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         self.assertEqual(self.algolia_index.search('')['nbHits'], 3)
         doc = self.elastic_doc.get_last_doc()
@@ -122,7 +122,7 @@ class AlgoliaDocManagerTester(AlgoliaTestCase):
 
         docc = {'_id': '6', 'name': 'HareTwin', '_ts': ts+4, 'ns': 'test.test'}
         self.elastic_doc.upsert(docc)
-        self.algolia_doc.commit(True)
+        self.algolia_doc.commit()
 
         doc = self.elastic_doc.get_last_doc()
         self.assertEqual(doc['_id'], '6')


### PR DESCRIPTION
- Removed unnecessary call to `self.run_auto_commit()` in constructor
- Replaced `BATCH_SIZE` and `AUTO_COMMIT_DELAY_S` to have the same constructor parameters as other doc managers.
- Added optional parameter `commit_sync` to use synchronous commits to algolia with a `False` default value
- Added optional parameter `commit_waittask_interval` with default value `1` (second) to reduce the number of `waitTask` requests (previously was 100ms, `waitTask` default value) 
